### PR TITLE
switch to finding jobs on executableName

### DIFF
--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -91,7 +91,7 @@ def find_jobs() -> list:
 
     jobs = [
         x for x in jobs
-        if x.get('describe', {}).get('name') == 'eggd_conductor'
+        if x.get('describe', {}).get('executableName') == 'eggd_conductor'
     ]
 
     log.info(


### PR DESCRIPTION
realised dx-streaming-upload so helpfully changes the job name on starting a job after completing an upload, so switching to use `executableName` field instead which should never change because its fixed by the app

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_monitor/4)
<!-- Reviewable:end -->
