### PR TITLE
fix bug in identifying run ID from sentinel file

### DIFF
--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -150,7 +150,7 @@ def get_run_ids(jobs) -> list:
     for job in jobs:
         job_input = job.get('describe', {}).get('originalInput', {})
 
-        sentinel = job_input.get('SENTINEL_FILE')
+        sentinel = job_input.get('upload_sentinel_record')
         run_id = job_input.get('RUN_ID')
         run_info_xml = job_input.get('RUN_INFO_XML')
 


### PR DESCRIPTION
- field name changed for sentinel file in eggd_conductor v1.1.1, requiring change in field queried to parse run ID

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_monitor/5)
<!-- Reviewable:end -->
