### PR TITLE
DI-1887 Fix bug by removing project_id from eggd_conductor job_ids output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ FROM python:3.12-alpine
 COPY eggd_conductor_monitor.py .
 COPY requirements.txt .
 
-RUN mkdir /logs/
-
-RUN apk add gcc musl-dev linux-headers python3-dev
-
 # - Install requirements
 # - Delete unnecessary Python files
 # - Alias command `s3_upload` to `python3 s3_upload.py` for convenience
+
 RUN \
+    mkdir /logs/ \
+    apk add gcc musl-dev linux-headers python3-dev \
     pip install --quiet --upgrade pip && \
     pip install -r requirements.txt && \
     echo "Delete python cache directories" 1>&2 && \
-    find /usr/local/lib/python3.12 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | xargs rm -rf {}
+    find /usr/local/lib/python3.12 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | xargs rm -rf {} && \
+    apk  --purge del gcc musl-dev linux-headers python3-dev

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -206,7 +206,8 @@ def get_launched_jobs(jobs) -> list:
 
     for job in jobs:
         output = job.get("describe").get("output").get("job_ids", "")
-        job["output"] = [x for x in output.split(",") if x]
+        job["output"] = [x for x in re.split(
+            "project-[a-zA-Z0-9]+:|,", output) if x]
 
         updated_jobs.append(job)
 


### PR DESCRIPTION
In Dockerfile:
- Combine all RUN commands into a single command
- Include a final RUN line to remove installed build dependencies.

In eggd_conductor_monitor.py:
- Remove the project-id from the job_ids output field of eggd_conductor jobs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_monitor/19)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimised Docker image by consolidating installation and cleanup steps, reducing image size.
- **Bug Fixes**
  - Improved job ID parsing to handle additional delimiter patterns, ensuring more reliable extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->