### PR TITLE
DI-2923 eggd conductor monitor v1.2.0 - Multiple project links

### DIFF
--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -539,6 +539,7 @@ def completed_run(run, executables, times, project) -> None:
 
     jira_comment(
         run_id=run["run_id"],
+        assay=assay,
         jira_message=jira_message,
         project_url=project_url,
         conductor_message=conductor_message,

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -493,7 +493,7 @@ def failed_run(run, project) -> None:
     # add Jira comment
     jira_message = (
         "Eggd_conductor_monitor: Automated job(s) failed processing "
-        f"for {assay} in run {run.get('run_id')} from {run.get('id')}."
+        f"for {assay} in run {run.get('run_id')} from {run.get('id')}.\n"
         f"Analysis project: "
     )
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -308,6 +308,8 @@ def jira_comment(
     ----------
     run_id : str
         run ID to match to Jira ticket
+    assay : str
+        assay to match to Jira ticket
     jira_message : str
         message to add to Jira comment
     job_id : str

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -520,7 +520,7 @@ def completed_run(run, executables, times, project) -> None:
 
     jira_executables = executables.replace(":black_small_square:", "-")
 
-    project_url = f"https://{url}"
+    project_url = f"{url}"
 
     jira_message = (
         "Eggd_conductor_monitor: All jobs "

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -424,7 +424,7 @@ def failed_run(run, project) -> None:
     channel = os.environ.get("SLACK_ALERT_CHANNEL")
     message = (
         ":x: eggd_conductor_monitor: Automated job(s) failed processing "
-        f"run *{run.get('run_id')}* from `{run.get('id')}`.\n"
+        f"for *{assay}* in run *{run.get('run_id')}* from `{run.get('id')}`.\n"
         f"Analysis project: {url}?state.values=failed"
     )
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -524,9 +524,10 @@ def completed_run(run, executables, times, project) -> None:
 
     jira_message = (
         "Eggd_conductor_monitor: All jobs "
-        f"completed successfully processing run {run.get('run_id')}.\n"
+        f"completed successfully processing "
+        f"for {assay} in run {run.get('run_id')}.\n"
         f"Total elapsed time: {total}\nPipeline runtime: {pipeline}\n"
-        f"Apps / workflows run: \n{jira_executables}\n"
+        f"Apps / workflows run: \n{jira_executables}"
         f"Analysis project: "
     )
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -619,7 +619,6 @@ def monitor():
     dx_login(os.environ.get("AUTH_TOKEN"))
 
     conductor_jobs = find_jobs(testing_job)
-    conductor_jobs = filter_notified_jobs(conductor_jobs)
     conductor_jobs = get_run_ids(conductor_jobs)
     conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
     project_states, total_states = get_all_job_states(jobs_by_project)
@@ -631,7 +630,7 @@ def monitor():
 
         log.info(f"Current state(s) for {job['id']}: {total_states}")
 
-        notified = filter_notified_projects(
+        unnotified = filter_notified_projects(
             job, project_states.keys())
 
         # check the state of each project with launched jobs and notify

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -469,19 +469,16 @@ def completed_run(run, executables, times, project) -> None:
     project : str
         analysis project ID
     """
-    log.info(f"All jobs completed for run {run['run_id']}")
 
-    # get url to downstream analysis added as tag to job
-    # filtering by beginning of url in case of multiple tags
-    url = "".join(
-        [
-            x
-            for x in run["describe"]["tags"]
-            if x.startswith("platform.dnanexus.com")
-        ]
+    assay = next((a for a, p in run['assay'] if p == project), None)
+
+    log.info(f"All jobs completed for {assay} "
+             f"in {project} for run {run['run_id']}")
+
+    url = (
+        "https://platform.dnanexus.com/panx/projects/"
+        f"{project.replace('project-', '')}/monitor/"
     )
-
-    url = url.replace("platform.dnanexus.com/", "platform.dnanexus.com/panx/")
 
     # calculate run time of pipeline and including conductor job
     pipeline = timedelta(seconds=times[1]) - timedelta(seconds=times[0])

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -646,50 +646,83 @@ def monitor():
     conductor_jobs = filter_notified_jobs(conductor_jobs)
     conductor_jobs = get_run_ids(conductor_jobs)
     conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
-    project_states = get_all_job_states(jobs_by_project)
+    project_states, total_states = get_all_job_states(jobs_by_project)
+
+    finished_states = {"done", "failed", "partially failed", "terminated"}
 
     for job in conductor_jobs:
         # get the state of all launched analysis jobs
 
+        log.info(f'Current state for {job["id"]}: {total_states}')
+
+        notified = filter_notified_projects(
+            job, project_states.keys())
+
+        # check the state of each project with launched jobs and notify
         for project, states in project_states.items():
-            all_states = states["all_states_count"]
-            all_executables = states["all_executables_count"]
-            times = states["times"]
-            log.info(f'Current state for jobs in {project}: {all_states}')
-
-            if all_states.get("failed") or all_states.get("partially failed"):
-                # something has failed => send an alert
-                failed_run(job, project)
-
-            elif set(all_states.keys()) == {"done"}:
-                # everything completed with no failed jobs => send notification
-                completed_run(job, all_executables, times, project)
-
-            elif set(all_states.keys()) == {"terminated"}:
-                # everything has been terminated => add the run ID to the
-                # notified log file to stop checking it
+            if project in notified:
                 log.info(
-                    f"All jobs terminated for {job['id']} "
-                    "=> stopping monitoring"
-                )
-                with open("logs/monitor_job_ids_notified.log", "a+") as fh:
-                    fh.write(f"{job['id']}\n")
-
-            elif not all_states:
-                # no job states => no launched jobs => stop monitoring
-                log.info(
-                    f"No launched jobs for {job['id']} => stopping monitoring"
-                )
-                with open("logs/monitor_job_ids_notified.log", "a+") as fh:
-                    fh.write(f"{job['id']}\n")
-
-            else:
-                # jobs still in progress
-                log.info(
-                    f"Jobs launched from {job['id']} "
-                    "have not failed or all completed"
+                    f"Already sent notification for {project} "
+                    f"=> skipping project"
                 )
                 continue
+
+            state = states["all_states_count"]
+            executables = states["all_executables_count"]
+            times = states["times"]
+            log.info(f'Current state for {project}: {state}')
+
+            # something has failed => send an alert
+            if state.get("failed") or state.get("partially failed"):
+                failed_run(job, project)
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job["id"]}:{project}\n")
+
+            # everything completed with no failed jobs => send notification
+            elif set(state.keys()) == {"done"}:
+                completed_run(job, executables, times, project)
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job["id"]}:{project}\n")
+
+            # everything has been terminated for that project =>
+            # stop monitoring
+            elif set(state.keys()) == {"terminated"}:
+                log.info(f"All jobs terminated for {project} "
+                         f"=> stopping monitoring")
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job["id"]}:{project}\n")
+
+        if set(total_states.keys()).issubset(finished_states):
+            # everything has been terminated => add the run ID to the
+            # notified log file to stop checking it
+            if set(total_states.keys()) == {"terminated"}:
+                log.info(
+                    f"All jobs terminated for {job['id']}"
+                    f"=> stopping monitoring"
+                )
+            else:
+                log.info(
+                    f"All jobs finished for {job['id']} => stopping monitoring"
+                )
+
+            with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+                fh.write(f"{job['id']}\n")
+
+        elif not total_states:
+            # no job states => no launched jobs => stop monitoring
+            log.info(
+                f"No launched jobs for {job['id']} => stopping monitoring"
+            )
+            with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+                fh.write(f"{job['id']}\n")
+
+        else:
+            # jobs still in progress
+            log.info(
+                f"Jobs launched from {job['id']} "
+                "have not failed or all completed"
+            )
+            continue
 
     log.info("Finished monitoring\n")
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -211,6 +211,7 @@ def get_launched_jobs(jobs) -> tuple[list, dict]:
         dict of job describe objects grouped by analysis project
     """
     updated_jobs = []
+    jobs_by_project = {}
 
     for job in jobs:
         output = job.get("describe").get("output").get("job_ids", "")
@@ -219,7 +220,11 @@ def get_launched_jobs(jobs) -> tuple[list, dict]:
 
         updated_jobs.append(job)
 
-    return updated_jobs
+        for match in re.finditer(r'(project-[a-zA-Z0-9]+):([^,]+)', output):
+            project, job_id = match.groups()
+            jobs_by_project.setdefault(project, []).append(job_id)
+
+    return updated_jobs, jobs_by_project
 
 
 def get_all_job_states(jobs) -> dict:

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -331,6 +331,11 @@ def jira_comment(
         all_tickets = jira.query_all_tickets()
         filtered_tickets = jira.filter_tickets_by_run(run_id, all_tickets)
 
+        if len(filtered_tickets) > 1:
+            filtered_tickets = jira.filter_tickets_by_assay(
+                assay, filtered_tickets
+                )
+
         project_id = os.environ.get("DX_PROJECT")
         job_url = (
             "https://platform.dnanexus.com/panx/projects/"

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -436,7 +436,7 @@ def failed_run(run, project) -> None:
         f"Analysis project: "
     )
 
-    project_url = f"https://{url}?state.values=failed"
+    project_url = f"{url}?state.values=failed"
     conductor_message = (
         "This run was processed automatically by eggd_conductor: "
     )

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -433,7 +433,7 @@ def slack_notify(channel, message, job_id=None) -> None:
     slack_token = os.environ.get("SLACK_TOKEN")
 
     http = Session()
-    retries = Retry(total=5, backoff_factor=10, method_whitelist=["POST"])
+    retries = Retry(total=5, backoff_factor=10, allowed_methods=["POST"])
     http.mount("https://", HTTPAdapter(max_retries=retries))
     try:
         response = http.post(

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -619,13 +619,13 @@ def monitor():
 
     conductor_jobs = find_jobs(testing_job)
     conductor_jobs = get_run_ids(conductor_jobs)
-    conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
-    project_states, total_states = get_all_job_states(jobs_by_project)
 
     finished_states = {"done", "failed", "partially failed", "terminated"}
 
     for job in conductor_jobs:
         # get the state of all launched analysis jobs
+        conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
+        project_states, total_states = get_all_job_states(jobs_by_project)
 
         log.info(f"Current state(s) for {job['id']}: {total_states}")
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -140,6 +140,35 @@ def filter_notified_jobs(jobs) -> list:
     return [x for x in jobs if x["id"] not in notified_jobs]
 
 
+def filter_notified_projects(job, projects) -> list:
+    """
+    Filter out project IDs of runs already notified
+
+    Parameters
+    ----------
+    job : list
+        job describe object
+    projects : list
+        list of project IDs
+
+    Returns
+    -------
+    list
+        list of project IDs where no Slack notification has been sent
+    """
+    with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+        fh.seek(0)
+        notified = fh.read().splitlines()
+
+    if notified:
+        log.info(
+            "Projects already notified via Slack or not to notify: "
+            f"{os.linesep}{notified}"
+        )
+
+    return [x for x in projects if f"{job["id"]}:{x}" in notified]
+
+
 def get_run_ids(jobs) -> list:
     """
     Get run ID and assay(s) for each job to know the run being processed.

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -424,7 +424,7 @@ def slack_notify(channel, message, job_id=None) -> None:
         else:
             # log job ID to know we sent an alert for it and not send another
             if job_id:
-                with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
                     fh.write(f"{job_id}\n")
     except Exception as err:
         log.error(
@@ -629,7 +629,7 @@ def monitor():
     for job in conductor_jobs:
         # get the state of all launched analysis jobs
 
-        log.info(f'Current state for {job['id']}: {total_states}')
+        log.info(f"Current state(s) for {job['id']}: {total_states}")
 
         notified = filter_notified_projects(
             job, project_states.keys())
@@ -646,23 +646,19 @@ def monitor():
             state = states["all_states_count"]
             executables = states["all_executables_count"]
             times = states["times"]
-            log.info(f'Current state for {project}: {state}')
+            log.info(f"Current state for {project} in {job['id']}: {state}")
 
             # something has failed => send an alert
             if state.get("failed") or state.get("partially failed"):
-                if failed_run(job, project):
-                    with open(
-                        "logs/monitor_project_ids_notified.log", "a+"
-                            ) as fh:
-                        fh.write(f"{job['id']}:{project}\n")
+                failed_run(job, project)
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job['id']}:{project}\n")
 
             # everything completed with no failed jobs => send notification
             elif set(state.keys()) == {"done"}:
-                if completed_run(job, executables, times, project):
-                    with open(
-                        "logs/monitor_project_ids_notified.log", "a+"
-                            ) as fh:
-                        fh.write(f"{job['id']}:{project}\n")
+                completed_run(job, executables, times, project)
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job['id']}:{project}\n")
 
             # everything has been terminated for that project =>
             # stop monitoring
@@ -685,7 +681,7 @@ def monitor():
                     f"All jobs finished for {job['id']} => stopping monitoring"
                 )
 
-            with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+            with open("logs/monitor_project_ids_notified.log", "a+") as fh:
                 fh.write(f"{job['id']}\n")
 
         elif not total_states:
@@ -693,7 +689,7 @@ def monitor():
             log.info(
                 f"No launched jobs for {job['id']} => stopping monitoring"
             )
-            with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+            with open("logs/monitor_project_ids_notified.log", "a+") as fh:
                 fh.write(f"{job['id']}\n")
 
         else:

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -299,7 +299,7 @@ def get_all_job_states(jobs_by_project) -> dict:
 
 
 def jira_comment(
-    run_id, jira_message, job_id, conductor_message, project_url
+    run_id, assay, jira_message, job_id, conductor_message, project_url
 ) -> None:
     """
     Add comment to Jira ticket linked to the run ID

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -224,7 +224,11 @@ def get_launched_jobs(jobs) -> tuple[list, dict]:
     jobs_by_project = {}
 
     for job in jobs:
-        output = job.get("describe").get("output").get("job_ids", "")
+
+        describe = job.get("describe") or {}
+        output_data = describe.get("output") or {}
+        output = output_data.get("job_ids", "")
+
         job["output"] = [x for x in re.split(
             "project-[a-zA-Z0-9]+:|,", output) if x]
 
@@ -422,7 +426,7 @@ def failed_run(run, project) -> None:
         analysis project ID
     """
 
-    assay = next((a for a, p in run['assay'] if p == project), "Unknown")
+    assay = next((a for a, p in run['assay'] if p == project), "unknown")
 
     log.info(f"Found failed jobs for {assay} "
              f"in {project} for run {run['run_id']}")
@@ -481,7 +485,7 @@ def completed_run(run, executables, times, project) -> None:
         analysis project ID
     """
 
-    assay = next((a for a, p in run['assay'] if p == project), "Unknown")
+    assay = next((a for a, p in run['assay'] if p == project), "unknown")
 
     log.info(f"All jobs completed for {assay} "
              f"in {project} for run {run['run_id']}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -593,10 +593,10 @@ def monitor():
     conductor_jobs = filter_notified_jobs(conductor_jobs)
     conductor_jobs = get_run_ids(conductor_jobs)
     conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
+    project_states = get_all_job_states(jobs_by_project)
 
     for job in conductor_jobs:
         # get the state of all launched analysis jobs
-        project_states = get_all_job_states(jobs_by_project)
 
         for project, states in project_states.items():
             all_states = states["all_states_count"]

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -432,7 +432,7 @@ def failed_run(run, project) -> None:
 
     jira_message = (
         "Eggd_conductor_monitor: Automated job(s) failed processing "
-        f"run {run.get('run_id')} from {run.get('id')}.\n"
+        f"for {assay} in run {run.get('run_id')} from {run.get('id')}."
         f"Analysis project: "
     )
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -399,7 +399,7 @@ def slack_notify(channel, message, job_id=None) -> None:
         )
 
 
-def failed_run(run) -> None:
+def failed_run(run, project) -> None:
     """
     Build message and sent Slack notification to alert of failed job(s)
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -167,7 +167,7 @@ def filter_notified_projects(job, projects) -> list:
             f"{os.linesep}{notified}"
         )
 
-    return [x for x in projects if f"{job["id"]}:{x}" in notified]
+    return [x for x in projects if f"{job['id']}:{x}" in notified]
 
 
 def get_run_ids(jobs) -> list:
@@ -654,7 +654,7 @@ def monitor():
     for job in conductor_jobs:
         # get the state of all launched analysis jobs
 
-        log.info(f'Current state for {job["id"]}: {total_states}')
+        log.info(f'Current state for {job['id']}: {total_states}')
 
         notified = filter_notified_projects(
             job, project_states.keys())
@@ -691,7 +691,7 @@ def monitor():
                 log.info(f"All jobs terminated for {project} "
                          f"=> stopping monitoring")
                 with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                    fh.write(f"{job["id"]}:{project}\n")
+                    fh.write(f"{job['id']}:{project}\n")
 
         if set(total_states.keys()).issubset(finished_states):
             # everything has been terminated => add the run ID to the

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -194,7 +194,7 @@ def get_run_ids(jobs) -> list:
     return updated_jobs
 
 
-def get_launched_jobs(jobs) -> list:
+def get_launched_jobs(jobs) -> tuple[list, dict]:
     """
     Parse out job IDs of launched jobs from eggd_conductor output
 
@@ -207,6 +207,8 @@ def get_launched_jobs(jobs) -> list:
     -------
     list
         list of job describe objects with launched jobs set to output
+    dict
+        dict of job describe objects grouped by analysis project
     """
     updated_jobs = []
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -185,6 +185,10 @@ def get_run_ids(jobs) -> list:
         log.info(f"Found run ID {run_id} for job {job['id']}")
 
         job["run_id"] = run_id
+
+        assay = job.get("describe").get("output").get("assay_config_file_ids")
+        job["assay"] = re.findall(
+            r'file-\w+:\s*(\w+)\s*-.*?->\s*(project-\w+)', assay)
         updated_jobs.append(job)
 
     return updated_jobs

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -511,7 +511,8 @@ def completed_run(run, executables, times, project) -> None:
     channel = os.environ.get("SLACK_LOG_CHANNEL")
     message = (
         ":white_check_mark: eggd_conductor_monitor: All jobs "
-        f"completed successfully processing run *{run.get('run_id')}*.\n"
+        f"completed successfully processing "
+        f"for *{assay}* in run *{run.get('run_id')}*.\n"
         f"Total elapsed time: *{total}*\nPipeline runtime: *{pipeline}*\n"
         f"Apps / workflows run: \n{executables}\n"
         f"Analysis project: {url}"

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -115,32 +115,6 @@ def find_jobs(testing_conductor_job) -> list:
     return jobs
 
 
-def filter_notified_jobs(jobs) -> list:
-    """
-    Filter out job IDs of runs already notified
-
-    Parameters
-    ----------
-    jobs : list
-        list of job describe objects
-
-    Returns
-    -------
-    list
-        list of job describe objects where no Slack notification has been sent
-    """
-    with open("logs/monitor_job_ids_notified.log", "a+") as fh:
-        fh.seek(0)
-        notified_jobs = fh.read().splitlines()
-
-    log.info(
-        "Jobs already notified via Slack or not to notify: "
-        f"{os.linesep}{notified_jobs}"
-    )
-
-    return [x for x in jobs if x["id"] not in notified_jobs]
-
-
 def filter_notified_projects(job, projects) -> list:
     """
     Filter out project IDs of runs already notified

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -668,7 +668,14 @@ def monitor():
                 with open("logs/monitor_project_ids_notified.log", "a+") as fh:
                     fh.write(f"{job['id']}:{project}\n")
 
-        if set(total_states.keys()).issubset(finished_states):
+        if not total_states:
+            # no job states => no launched jobs => stop monitoring
+            log.info(
+                f"No launched jobs for {job['id']} => stopping monitoring"
+            )
+            continue
+
+        elif set(total_states.keys()).issubset(finished_states):
             # everything has been terminated => add the run ID to the
             # notified log file to stop checking it
             if set(total_states.keys()) == {"terminated"}:
@@ -680,21 +687,6 @@ def monitor():
                 log.info(
                     f"All jobs finished for {job['id']} => stopping monitoring"
                 )
-
-            for project, states in project_states.items():
-                entry = f"{job['id']}:{project}"
-                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                    fh.seek(0)
-                    if entry not in fh.read().splitlines():
-                        fh.write(f"{job['id']}:{project}\n")
-
-        elif not total_states:
-            # no job states => no launched jobs => stop monitoring
-            log.info(
-                f"No launched jobs for {job['id']} => stopping monitoring"
-            )
-            with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                fh.write(f"{job['id']}:{project}\n")
 
         else:
             # jobs still in progress

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -186,7 +186,9 @@ def get_run_ids(jobs) -> list:
 
         job["run_id"] = run_id
 
-        assay = job.get("describe").get("output").get("assay_config_file_ids")
+        describe = job.get("describe") or {}
+        output = describe.get("output") or {}
+        assay = output.get("assay_config_file_ids")
 
         if not assay:
             # failed to correctly get assay
@@ -194,8 +196,9 @@ def get_run_ids(jobs) -> list:
 
         log.info(f"Found assay {assay} for {job['id']}")
 
-        job["assay"] = re.findall(
+        parsed_assays = re.findall(
             r'file-\w+:\s*(\w+)\s*-.*?->\s*(project-\w+)', assay)
+        job["assay"] = parsed_assays if parsed_assays else [("unknown", "")]
         updated_jobs.append(job)
 
     return updated_jobs

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -407,20 +407,19 @@ def failed_run(run, project) -> None:
     ----------
     run : dict
         dx describe object of given run
+    project : str
+        analysis project ID
     """
-    log.info(f"Found failed jobs for run {run['run_id']}")
 
-    # get url to downstream analysis added as tag to job
-    # filtering by beginning of url in case of multiple tags
-    url = "".join(
-        [
-            x
-            for x in run["describe"]["tags"]
-            if x.startswith("platform.dnanexus.com")
-        ]
+    assay = next((a for a, p in run['assay'] if p == project), None)
+
+    log.info(f"Found failed jobs for {assay} "
+             f"in {project} for run {run['run_id']}")
+
+    url = (
+        "https://platform.dnanexus.com/panx/projects/"
+        f"{project.replace('project-', '')}/monitor/"
     )
-
-    url = url.replace("platform.dnanexus.com/", "platform.dnanexus.com/panx/")
 
     channel = os.environ.get("SLACK_ALERT_CHANNEL")
     message = (

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -187,6 +187,13 @@ def get_run_ids(jobs) -> list:
         job["run_id"] = run_id
 
         assay = job.get("describe").get("output").get("assay_config_file_ids")
+
+        if not assay:
+            # failed to correctly get assay
+            assay = "unknown"
+
+        log.info(f"Found assay {assay} for {job['id']}")
+
         job["assay"] = re.findall(
             r'file-\w+:\s*(\w+)\s*-.*?->\s*(project-\w+)', assay)
         updated_jobs.append(job)
@@ -219,7 +226,7 @@ def get_launched_jobs(jobs) -> tuple[list, dict]:
             "project-[a-zA-Z0-9]+:|,", output) if x]
 
         updated_jobs.append(job)
-
+        # group jobs by project id
         for match in re.finditer(r'(project-[a-zA-Z0-9]+):([^,]+)', output):
             project, job_id = match.groups()
             jobs_by_project.setdefault(project, []).append(job_id)
@@ -331,6 +338,7 @@ def jira_comment(
         all_tickets = jira.query_all_tickets()
         filtered_tickets = jira.filter_tickets_by_run(run_id, all_tickets)
 
+        # filter by assay code if multiple tickets
         if len(filtered_tickets) > 1:
             filtered_tickets = jira.filter_tickets_by_assay(
                 assay, filtered_tickets
@@ -420,7 +428,7 @@ def failed_run(run, project) -> None:
         "https://platform.dnanexus.com/panx/projects/"
         f"{project.replace('project-', '')}/monitor/"
     )
-
+    # send Slack notification
     channel = os.environ.get("SLACK_ALERT_CHANNEL")
     message = (
         ":x: eggd_conductor_monitor: Automated job(s) failed processing "
@@ -429,7 +437,7 @@ def failed_run(run, project) -> None:
     )
 
     slack_notify(channel=channel, message=message, job_id=run["id"])
-
+    # add Jira comment
     jira_message = (
         "Eggd_conductor_monitor: Automated job(s) failed processing "
         f"for {assay} in run {run.get('run_id')} from {run.get('id')}."
@@ -465,7 +473,7 @@ def completed_run(run, executables, times, project) -> None:
 
     times : tuple
         first job start time and last job finished time
-    
+
     project : str
         analysis project ID
     """
@@ -507,7 +515,7 @@ def completed_run(run, executables, times, project) -> None:
     executables = "".join(
         [f":black_small_square: {v}x {k}\n" for k, v in executables.items()]
     )
-
+    # send Slack message
     channel = os.environ.get("SLACK_LOG_CHANNEL")
     message = (
         ":white_check_mark: eggd_conductor_monitor: All jobs "
@@ -518,6 +526,9 @@ def completed_run(run, executables, times, project) -> None:
         f"Analysis project: {url}"
     )
 
+    slack_notify(channel=channel, message=message, job_id=run["id"])
+
+    # add Jira comment
     jira_executables = executables.replace(":black_small_square:", "-")
 
     project_url = f"{url}"
@@ -534,8 +545,6 @@ def completed_run(run, executables, times, project) -> None:
     conductor_message = (
         "This run was processed automatically by eggd_conductor: "
     )
-
-    slack_notify(channel=channel, message=message, job_id=run["id"])
 
     jira_comment(
         run_id=run["run_id"],

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -350,10 +350,9 @@ def jira_comment(
         filtered_tickets = jira.filter_tickets_by_run(run_id, all_tickets)
 
         # filter by assay code if multiple tickets
-        if len(filtered_tickets) > 1:
-            filtered_tickets = jira.filter_tickets_by_assay(
-                assay, filtered_tickets
-                )
+
+        filtered_tickets = jira.filter_tickets_by_assay(
+            assay, filtered_tickets)
 
         project_id = os.environ.get("DX_PROJECT")
         job_url = (
@@ -373,7 +372,7 @@ def jira_comment(
 
         # add comment to Jira ticket for run to link to
         # this eggd_conductor job
-        elif len(filtered_tickets) == 1:
+        else:
             for ticket in filtered_tickets:
                 log.info(
                     f"Adding comment to Jira ticket {ticket['id']} "

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -616,7 +616,7 @@ def monitor():
                 # everything has been terminated => add the run ID to the
                 # notified log file to stop checking it
                 log.info(
-                    f"All jobs terminated for {job['id']}"
+                    f"All jobs terminated for {job['id']} "
                     "=> stopping monitoring"
                 )
                 with open("logs/monitor_job_ids_notified.log", "a+") as fh:

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -121,7 +121,7 @@ def filter_notified_projects(job, projects) -> list:
 
     Parameters
     ----------
-    job : list
+    job : dict
         job describe object
     projects : list
         list of project IDs

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -281,6 +281,7 @@ def get_all_job_states(jobs_by_project) -> dict:
         mapping of project to states, executables, and times
     """
     project_states = {}
+    total_states = {}
 
     for project, job_ids in jobs_by_project.items():
         all_states = []
@@ -334,7 +335,10 @@ def get_all_job_states(jobs_by_project) -> dict:
             "times": times,
         }
 
-    return project_states
+        for state, count in all_states_count.items():
+            total_states[state] = total_states.get(state, 0) + count
+
+    return project_states, total_states
 
 
 def jira_comment(

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -490,7 +490,8 @@ def failed_run(run, project) -> None:
         f"Analysis project: {url}?state.values=failed"
     )
 
-    slack_notify(channel=channel, message=message, job_id=run["id"])
+    slack_notify(channel=channel, message=message)
+
     # add Jira comment
     jira_message = (
         "Eggd_conductor_monitor: Automated job(s) failed processing "
@@ -583,7 +584,7 @@ def completed_run(run, executables, times, project) -> None:
         f"Analysis project: {url}"
     )
 
-    slack_notify(channel=channel, message=message, job_id=run["id"])
+    slack_notify(channel=channel, message=message)
 
     # add Jira comment
     jira_executables = executables.replace(":black_small_square:", "-")
@@ -675,15 +676,19 @@ def monitor():
 
             # something has failed => send an alert
             if state.get("failed") or state.get("partially failed"):
-                failed_run(job, project)
-                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                    fh.write(f"{job["id"]}:{project}\n")
+                if failed_run(job, project):
+                    with open(
+                        "logs/monitor_project_ids_notified.log", "a+"
+                            ) as fh:
+                        fh.write(f"{job['id']}:{project}\n")
 
             # everything completed with no failed jobs => send notification
             elif set(state.keys()) == {"done"}:
-                completed_run(job, executables, times, project)
-                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                    fh.write(f"{job["id"]}:{project}\n")
+                if completed_run(job, executables, times, project):
+                    with open(
+                        "logs/monitor_project_ids_notified.log", "a+"
+                            ) as fh:
+                        fh.write(f"{job['id']}:{project}\n")
 
             # everything has been terminated for that project =>
             # stop monitoring

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -626,7 +626,7 @@ def monitor():
 
     for job in conductor_jobs:
         # get the state of all launched analysis jobs for given conductor job
-        _, jobs_by_project = get_launched_jobs(conductor_jobs)
+        _, jobs_by_project = get_launched_jobs([job])
         project_states, total_states = get_all_job_states(jobs_by_project)
 
         log.info(f"Current state(s) for {job['id']}: {total_states}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -233,16 +233,15 @@ def get_all_job_states(jobs) -> dict:
 
     Parameters
     ----------
-    jobs : list
-        list of job describe objects
+    jobs_by_project : dict
+        mapping of project IDs to job IDs
 
     Returns
     -------
-    all_states_counts : dict
-        mapping of state to total jobs
-
-    all_executables_count : dict
-        mapping of executableNames to count of each executable
+    project_states : dict
+        mapping of project to states, executables, and times
+    """
+    project_states = {}
 
     times : tuple
         first job start time and last job finished time

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -227,7 +227,7 @@ def get_launched_jobs(jobs) -> tuple[list, dict]:
     return updated_jobs, jobs_by_project
 
 
-def get_all_job_states(jobs) -> dict:
+def get_all_job_states(jobs_by_project) -> dict:
     """
     Get the state of all launched jobs
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -243,54 +243,59 @@ def get_all_job_states(jobs_by_project) -> dict:
     """
     project_states = {}
 
-    times : tuple
-        first job start time and last job finished time
-    """
-    all_states = []
-    all_executables = []
-    started = []
-    stopped = []
+    for project, job_ids in jobs_by_project.items():
+        all_states = []
+        all_executables = []
+        started = []
+        stopped = []
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
-        # submit query to get state of job / analysis
-        concurrent_jobs = {
-            executor.submit(dx.describe, id): id for id in jobs["output"]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
+            # submit query to get state of job / analysis
+            concurrent_jobs = {
+                executor.submit(dx.describe, id): id for id in job_ids
+            }
+            for future in concurrent.futures.as_completed(concurrent_jobs):
+                # access returned output as each is returned in any order
+                try:
+                    describe = future.result()
+                    all_states.append(describe.get("state"))
+                    all_executables.append(describe.get("executableName"))
+                    started.append(describe["created"])
+                    stopped.append(describe["modified"])
+                except Exception as exc:
+                    # catch any errors that might get raised during querying
+                    log.error(
+                        f"Error getting data for "
+                        f"{concurrent_jobs[future]}: {exc}"
+                    )
+
+        # get a count of each state
+        all_states_count = {}
+        for state in set(all_states):
+            all_states_count[state] = all_states.count(state)
+
+        # get a count of each executable
+        all_executables_count = {}
+        for exe in set(all_executables):
+            all_executables_count[exe] = all_executables.count(exe)
+
+        # get earliest job start time and end time of latest running job
+        if started and stopped:
+            times = (min(started) / 1000, max(stopped) / 1000)
+        else:
+            # if querying is immediately after launching jobs (or the
+            # eggd_conductor job did not launch any jobs) then the created
+            # and modified metadata fields may be null => only calculate if
+            # something is present, else just return zeros
+            times = (0, 0)
+
+        project_states[project] = {
+            "all_states_count": all_states_count,
+            "all_executables_count": all_executables_count,
+            "times": times,
         }
-        for future in concurrent.futures.as_completed(concurrent_jobs):
-            # access returned output as each is returned in any order
-            try:
-                describe = future.result()
-                all_states.append(describe.get("state"))
-                all_executables.append(describe.get("executableName"))
-                started.append(describe["created"])
-                stopped.append(describe["modified"])
-            except Exception as exc:
-                # catch any errors that might get raised during querying
-                log.error(
-                    f"Error getting data for {concurrent_jobs[future]}: {exc}"
-                )
 
-    # get a count of each state
-    all_states_count = {}
-    for state in set(all_states):
-        all_states_count[state] = all_states.count(state)
-
-    # get a count of each executable
-    all_executables_count = {}
-    for exe in set(all_executables):
-        all_executables_count[exe] = all_executables.count(exe)
-
-    # get earliest job start time and end time of latest running job
-    if started and stopped:
-        times = (min(started) / 1000, max(stopped) / 1000)
-    else:
-        # if querying is immediately after launching jobs (or the
-        # eggd_conductor job did not launch any jobs) then the created
-        # and modified metadata fields may be null => only calculate if
-        # something is present, else just return zeros
-        times = (0, 0)
-
-    return all_states_count, all_executables_count, times
+    return project_states
 
 
 def jira_comment(

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -4,6 +4,7 @@ via Slack for any fails or when all successfully complete
 """
 
 import concurrent
+import concurrent.futures
 from datetime import timedelta
 import logging
 import os

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -390,7 +390,7 @@ def jira_comment(
         log.error(f"Error in adding Jira comment for {run_id}: {err}")
 
 
-def slack_notify(channel, message, job_id=None) -> None:
+def slack_notify(channel, message, job_id=None, project=None) -> None:
     """
     Send notification to given Slack channel
 
@@ -402,6 +402,8 @@ def slack_notify(channel, message, job_id=None) -> None:
         message to send to Slack
     job_id : str
         DNAnexus ID of eggd_conductor job
+    project : str
+        DNAnexus ID of analysis project
     """
     log.info(f"Sending message to {channel}")
     slack_token = os.environ.get("SLACK_TOKEN")
@@ -424,7 +426,7 @@ def slack_notify(channel, message, job_id=None) -> None:
             # log job ID to know we sent an alert for it and not send another
             if job_id:
                 with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                    fh.write(f"{job_id}\n")
+                    fh.write(f"{job_id}:{project}\n")
     except Exception as err:
         log.error(
             f"Error in sending post request for slack notification: {err}"
@@ -679,8 +681,12 @@ def monitor():
                     f"All jobs finished for {job['id']} => stopping monitoring"
                 )
 
-            with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                fh.write(f"{job['id']}\n")
+            for project, states in project_states.items():
+                entry = f"{job['id']}:{project}"
+                with open("logs/monitor_project_ids_notified.log", "a+") as fh:
+                    fh.seek(0)
+                    if entry not in fh.read().splitlines():
+                        fh.write(f"{job['id']}:{project}\n")
 
         elif not total_states:
             # no job states => no launched jobs => stop monitoring
@@ -688,7 +694,7 @@ def monitor():
                 f"No launched jobs for {job['id']} => stopping monitoring"
             )
             with open("logs/monitor_project_ids_notified.log", "a+") as fh:
-                fh.write(f"{job['id']}\n")
+                fh.write(f"{job['id']}:{project}\n")
 
         else:
             # jobs still in progress

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -165,6 +165,7 @@ def get_run_ids(jobs) -> list:
 
     for job in jobs:
         job_input = job.get("describe", {}).get("originalInput", {})
+        run_id = ""
 
         run_id_matches = [
             re.search(r"run_id", ele, re.IGNORECASE) for ele in job_input
@@ -180,7 +181,6 @@ def get_run_ids(jobs) -> list:
             run_id = job_input.get(
                 [match.group(0) for match in run_id_matches if match][0]
             )
-            continue
 
         if not run_id:
             # failed to correctly get run id

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -390,13 +390,27 @@ def jira_comment(
         # add comment to Jira ticket for run to link to
         # this eggd_conductor job
         for ticket in filtered_tickets:
-            jira.add_comment(
-                comment=jira_message,
-                project_url=project_url,
-                conductor_message=conductor_message,
-                url=job_url,
-                ticket=ticket["id"],
-            )
+            if len(filtered_tickets) == 1:
+                log.info(
+                    f"Adding comment to Jira ticket {ticket['id']} "
+                    f"for run {run_id}"
+                )
+                jira.add_comment(
+                    comment=jira_message,
+                    project_url=project_url,
+                    conductor_message=conductor_message,
+                    url=job_url,
+                    ticket=ticket["id"],
+                 )
+
+        if len(filtered_tickets) != 1:
+            # send Slack notification
+            channel = os.environ.get("SLACK_ALERT_CHANNEL")
+            message = (
+                ":x: eggd_conductor_monitor: Error finding Jira ticket "
+                f"for run *{run_id}* and *{assay}* assay: "
+                f"found {len(filtered_tickets)} matching tickets.")
+            slack_notify(channel=channel, message=message)
 
     except Exception as err:
         log.error(f"Error in adding Jira comment for {run_id}: {err}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -422,7 +422,10 @@ def failed_run(run, project) -> None:
         analysis project ID
     """
 
-    assay = next((a for a, p in run['assay'] if p == project), "unknown")
+    assay = next(
+        (assay_type for assay_type, project_name in run['assay']
+         if project_name == project), "unknown"
+         )
 
     log.info(f"Found failed jobs for {assay} "
              f"in {project} for run {run['run_id']}")
@@ -481,7 +484,10 @@ def completed_run(run, executables, times, project) -> None:
         analysis project ID
     """
 
-    assay = next((a for a, p in run['assay'] if p == project), "unknown")
+    assay = next(
+        (assay_type for assay_type, project_name in run['assay']
+         if project_name == project), "unknown"
+         )
 
     log.info(f"All jobs completed for {assay} "
              f"in {project} for run {run['run_id']}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -142,7 +142,7 @@ def filter_notified_jobs(jobs) -> list:
 
 def get_run_ids(jobs) -> list:
     """
-    Get run ID for each job to know the run being processed.
+    Get run ID and assay for each job to know the run being processed.
 
     This is either parsed from the sentinel record if used, or from the
     run_id input or RunInfo.xml file
@@ -155,7 +155,7 @@ def get_run_ids(jobs) -> list:
     Returns
     -------
     list
-        list of job describe objects, including run IDs
+        list of job describe objects, including run IDs and assays
     """
     updated_jobs = []
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -580,45 +580,51 @@ def monitor():
     conductor_jobs = find_jobs(testing_job)
     conductor_jobs = filter_notified_jobs(conductor_jobs)
     conductor_jobs = get_run_ids(conductor_jobs)
-    conductor_jobs = get_launched_jobs(conductor_jobs)
+    conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
 
     for job in conductor_jobs:
         # get the state of all launched analysis jobs
-        all_states, all_executables, times = get_all_job_states(job)
-        log.info(f'Current state for {job["id"]}: {all_states}')
+        project_states = get_all_job_states(jobs_by_project)
 
-        if all_states.get("failed") or all_states.get("partially failed"):
-            # something has failed => send an alert
-            failed_run(job)
+        for project, states in project_states.items():
+            all_states = states["all_states_count"]
+            all_executables = states["all_executables_count"]
+            times = states["times"]
+            log.info(f'Current state for jobs in {project}: {all_states}')
 
-        elif list(all_states.keys()) == ["done"]:
-            # everything completed with no failed jobs => send notification
-            completed_run(job, all_executables, times)
+            if all_states.get("failed") or all_states.get("partially failed"):
+                # something has failed => send an alert
+                failed_run(job, project)
 
-        elif list(all_states.keys()) == ["terminated"]:
-            # everything has been terminated => add the run ID to the
-            # notified log file to stop checking it
-            log.info(
-                f"All jobs terminated for {job['id']} => stopping monitoring"
-            )
-            with open("logs/monitor_job_ids_notified.log", "a+") as fh:
-                fh.write(f"{job['id']}\n")
+            elif set(all_states.keys()) == {"done"}:
+                # everything completed with no failed jobs => send notification
+                completed_run(job, all_executables, times, project)
 
-        elif not all_states:
-            # no job states => no launched jobs => stop monitoring
-            log.info(
-                f"No launched jobs for {job['id']} => stopping monitoring"
-            )
-            with open("logs/monitor_job_ids_notified.log", "a+") as fh:
-                fh.write(f"{job['id']}\n")
+            elif set(all_states.keys()) == {"terminated"}:
+                # everything has been terminated => add the run ID to the
+                # notified log file to stop checking it
+                log.info(
+                    f"All jobs terminated for {job['id']}"
+                    "=> stopping monitoring"
+                )
+                with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job['id']}\n")
 
-        else:
-            # jobs still in progress
-            log.info(
-                f"Jobs launched from {job['id']} "
-                "have not failed or all completed"
-            )
-            continue
+            elif not all_states:
+                # no job states => no launched jobs => stop monitoring
+                log.info(
+                    f"No launched jobs for {job['id']} => stopping monitoring"
+                )
+                with open("logs/monitor_job_ids_notified.log", "a+") as fh:
+                    fh.write(f"{job['id']}\n")
+
+            else:
+                # jobs still in progress
+                log.info(
+                    f"Jobs launched from {job['id']} "
+                    "have not failed or all completed"
+                )
+                continue
 
     log.info("Finished monitoring\n")
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -625,8 +625,8 @@ def monitor():
     finished_states = {"done", "failed", "partially failed", "terminated"}
 
     for job in conductor_jobs:
-        # get the state of all launched analysis jobs
-        conductor_jobs, jobs_by_project = get_launched_jobs(conductor_jobs)
+        # get the state of all launched analysis jobs for given conductor job
+        _, jobs_by_project = get_launched_jobs(conductor_jobs)
         project_states, total_states = get_all_job_states(jobs_by_project)
 
         log.info(f"Current state(s) for {job['id']}: {total_states}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -451,7 +451,7 @@ def failed_run(run, project) -> None:
     )
 
 
-def completed_run(run, executables, times) -> None:
+def completed_run(run, executables, times, project) -> None:
     """
     Build message and sent Slack notification for completed run
 
@@ -465,6 +465,9 @@ def completed_run(run, executables, times) -> None:
 
     times : tuple
         first job start time and last job finished time
+    
+    project : str
+        analysis project ID
     """
     log.info(f"All jobs completed for run {run['run_id']}")
 

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -422,7 +422,7 @@ def failed_run(run, project) -> None:
         analysis project ID
     """
 
-    assay = next((a for a, p in run['assay'] if p == project), None)
+    assay = next((a for a, p in run['assay'] if p == project), "Unknown")
 
     log.info(f"Found failed jobs for {assay} "
              f"in {project} for run {run['run_id']}")
@@ -481,7 +481,7 @@ def completed_run(run, executables, times, project) -> None:
         analysis project ID
     """
 
-    assay = next((a for a, p in run['assay'] if p == project), None)
+    assay = next((a for a, p in run['assay'] if p == project), "Unknown")
 
     log.info(f"All jobs completed for {assay} "
              f"in {project} for run {run['run_id']}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -141,7 +141,7 @@ def filter_notified_projects(job, projects) -> list:
             f"{os.linesep}{notified}"
         )
 
-    return [x for x in projects if f"{job['id']}:{x}" in notified]
+    return [x for x in projects if f"{job['id']}:{x}" not in notified]
 
 
 def get_run_ids(jobs) -> list:
@@ -636,7 +636,7 @@ def monitor():
 
         # check the state of each project with launched jobs and notify
         for project, states in project_states.items():
-            if project in notified:
+            if project not in unnotified:
                 log.info(
                     f"Already sent notification for {project} "
                     f"=> skipping project"

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -7,6 +7,7 @@ import concurrent
 import concurrent.futures
 from datetime import timedelta
 import logging
+import logging.handlers
 import os
 import re
 from requests import Session
@@ -275,8 +276,12 @@ def get_all_job_states(jobs_by_project) -> dict:
                     describe = future.result()
                     all_states.append(describe.get("state"))
                     all_executables.append(describe.get("executableName"))
-                    started.append(describe["created"])
-                    stopped.append(describe["modified"])
+                    created = describe.get("created")
+                    modified = describe.get("modified")
+                    if created is not None:
+                        started.append(created)
+                    if modified is not None:
+                        stopped.append(modified)
                 except Exception as exc:
                     # catch any errors that might get raised during querying
                     log.error(

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -634,6 +634,13 @@ def monitor():
         unnotified = filter_notified_projects(
             job, project_states.keys())
 
+        if not total_states:
+            # no job states => no launched jobs => stop monitoring
+            log.info(
+                f"No launched jobs for {job['id']} => stopping monitoring"
+            )
+            continue
+
         # check the state of each project with launched jobs and notify
         for project, states in project_states.items():
             if project not in unnotified:
@@ -668,16 +675,8 @@ def monitor():
                 with open("logs/monitor_project_ids_notified.log", "a+") as fh:
                     fh.write(f"{job['id']}:{project}\n")
 
-        if not total_states:
-            # no job states => no launched jobs => stop monitoring
-            log.info(
-                f"No launched jobs for {job['id']} => stopping monitoring"
-            )
-            continue
-
-        elif set(total_states.keys()).issubset(finished_states):
-            # everything has been terminated => add the run ID to the
-            # notified log file to stop checking it
+        if set(total_states.keys()).issubset(finished_states):
+            # everything has finished for the job => add to log
             if set(total_states.keys()) == {"terminated"}:
                 log.info(
                     f"All jobs terminated for {job['id']}"
@@ -689,7 +688,7 @@ def monitor():
                 )
 
         else:
-            # jobs still in progress
+            # jobs still in progress => continue monitoring
             log.info(
                 f"Jobs launched from {job['id']} "
                 "have not failed or all completed"

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -388,10 +388,19 @@ def jira_comment(
             f"job/{job_id.replace('job-', '')}"
         )
 
+        if len(filtered_tickets) != 1:
+            # send Slack notification
+            channel = os.environ.get("SLACK_ALERT_CHANNEL")
+            message = (
+                ":x: eggd_conductor_monitor: Error finding Jira ticket "
+                f"for run *{run_id}* and *{assay}* assay: "
+                f"found {len(filtered_tickets)} matching tickets.")
+            slack_notify(channel=channel, message=message)
+
         # add comment to Jira ticket for run to link to
         # this eggd_conductor job
-        for ticket in filtered_tickets:
-            if len(filtered_tickets) == 1:
+        elif len(filtered_tickets) == 1:
+            for ticket in filtered_tickets:
                 log.info(
                     f"Adding comment to Jira ticket {ticket['id']} "
                     f"for run {run_id}"
@@ -403,15 +412,6 @@ def jira_comment(
                     url=job_url,
                     ticket=ticket["id"],
                  )
-
-        if len(filtered_tickets) != 1:
-            # send Slack notification
-            channel = os.environ.get("SLACK_ALERT_CHANNEL")
-            message = (
-                ":x: eggd_conductor_monitor: Error finding Jira ticket "
-                f"for run *{run_id}* and *{assay}* assay: "
-                f"found {len(filtered_tickets)} matching tickets.")
-            slack_notify(channel=channel, message=message)
 
     except Exception as err:
         log.error(f"Error in adding Jira comment for {run_id}: {err}")

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -142,7 +142,7 @@ def filter_notified_jobs(jobs) -> list:
 
 def get_run_ids(jobs) -> list:
     """
-    Get run ID and assay for each job to know the run being processed.
+    Get run ID and assay(s) for each job to know the run being processed.
 
     This is either parsed from the sentinel record if used, or from the
     run_id input or RunInfo.xml file
@@ -155,7 +155,7 @@ def get_run_ids(jobs) -> list:
     Returns
     -------
     list
-        list of job describe objects, including run IDs and assays
+        list of job describe objects, including run IDs and assay(s)
     """
     updated_jobs = []
 
@@ -194,7 +194,7 @@ def get_run_ids(jobs) -> list:
             # failed to correctly get assay
             assay = "unknown"
 
-        log.info(f"Found assay {assay} for {job['id']}")
+        log.info(f"Found assay(s) {assay} for {job['id']}")
 
         parsed_assays = re.findall(
             r'file-\w+:\s*(\w+)\s*-.*?->\s*(project-\w+)', assay)

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -443,6 +443,7 @@ def failed_run(run, project) -> None:
 
     jira_comment(
         run_id=run["run_id"],
+        assay=assay,
         jira_message=jira_message,
         project_url=project_url,
         conductor_message=conductor_message,

--- a/eggd_conductor_monitor.py
+++ b/eggd_conductor_monitor.py
@@ -186,13 +186,9 @@ def get_run_ids(jobs) -> list:
 
         job["run_id"] = run_id
 
-        describe = job.get("describe") or {}
-        output = describe.get("output") or {}
-        assay = output.get("assay_config_file_ids")
-
-        if not assay:
-            # failed to correctly get assay
-            assay = "unknown"
+        describe = job.get("describe", {})
+        output = describe.get("output", {})
+        assay = output.get("assay_config_file_ids", "unknown")
 
         log.info(f"Found assay(s) {assay} for {job['id']}")
 
@@ -225,8 +221,8 @@ def get_launched_jobs(jobs) -> tuple[list, dict]:
 
     for job in jobs:
 
-        describe = job.get("describe") or {}
-        output_data = describe.get("output") or {}
+        describe = job.get("describe", {})
+        output_data = describe.get("output", {})
         output = output_data.get("job_ids", "")
 
         job["output"] = [x for x in re.split(

--- a/utils/jira_functions.py
+++ b/utils/jira_functions.py
@@ -100,6 +100,30 @@ class Jira:
 
         return run_tickets
 
+    def filter_tickets_by_assay(self, assay, tickets) -> list:
+        """
+        Filter a list of tickets to find the one associated with a given assay
+
+        Parameters
+        ----------
+        assay : str
+            assay of the sequencing run
+        tickets : list
+            list of tickets to filter through
+
+        Returns
+        -------
+        list
+            list of matching tickets
+        """
+
+        assay_tickets = [
+            x for x in tickets
+            if x["fields"]["customfield_10070"][0]["value"] in assay
+            ]
+
+        return assay_tickets
+
     def add_comment(self, comment, project_url, conductor_message, url,
                     ticket=None) -> None:
         """

--- a/utils/jira_functions.py
+++ b/utils/jira_functions.py
@@ -119,7 +119,8 @@ class Jira:
 
         assay_tickets = [
             x for x in tickets
-            if x["fields"]["customfield_10070"][0]["value"] in assay
+            if x.get("fields", {}).get("customfield_10070")
+            and x["fields"]["customfield_10070"][0].get("value", "") in assay
             ]
 
         return assay_tickets

--- a/utils/jira_functions.py
+++ b/utils/jira_functions.py
@@ -119,10 +119,12 @@ class Jira:
 
         assay_tickets = [
             x for x in tickets
-            if x.get("fields", {}).get("customfield_10070")
-            and assay.strip("38_")
-            in x["fields"]["customfield_10070"][0].get("value", "")
-            ]
+            if assay.strip("38_") in (
+                ((x.get("fields") or {})
+                 .get("customfield_10070") or [{}])[0]
+                .get("value", "")
+            )
+        ]
 
         return assay_tickets
 

--- a/utils/jira_functions.py
+++ b/utils/jira_functions.py
@@ -120,7 +120,8 @@ class Jira:
         assay_tickets = [
             x for x in tickets
             if x.get("fields", {}).get("customfield_10070")
-            and x["fields"]["customfield_10070"][0].get("value", "") in assay
+            and assay.strip("38_")
+            in x["fields"]["customfield_10070"][0].get("value", "")
             ]
 
         return assay_tickets


### PR DESCRIPTION
- Add logic to filter tickets by assay for runs with multiple assays
- Addresses issue: https://github.com/eastgenomics/eggd_conductor_monitor/issues/22

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor_monitor/26)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel monitoring across projects for faster status checks.
  * Per-project Slack and Jira notifications with project-scoped de-duplication.
  * Assay-aware run tracking and Jira filtering to target relevant tickets.

* **Refactor**
  * Notifications and state aggregation reworked to operate per project; monitoring stops when all projects complete.

* **Bug Fixes**
  * Improved Slack alerts and handling when ticket filtering yields unexpected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->